### PR TITLE
Ensure nightlies are uploaded to the correct bucket

### DIFF
--- a/scripts/nightly/upload.py
+++ b/scripts/nightly/upload.py
@@ -15,11 +15,11 @@ except StopIteration:
 
 print("Uploading", f.name)
 s3 = boto3.client('s3')
-s3.upload_file(str(f), 'releases.wagtail.org', 'nightly/dist/' + f.name, ExtraArgs={'ACL': 'public-read'})
+s3.upload_file(str(f), 'releases.wagtail.io', 'nightly/dist/' + f.name, ExtraArgs={'ACL': 'public-read'})
 
 print("Updating latest.json")
 
-boto3.resource('s3').Object('releases.wagtail.org', 'nightly/latest.json').put(
+boto3.resource('s3').Object('releases.wagtail.io', 'nightly/latest.json').put(
     ACL='public-read',
     Body=json.dumps({
         "url": 'https://releases.wagtail.org/nightly/dist/' + f.name,


### PR DESCRIPTION
A regression from https://github.com/wagtail/wagtail/pull/7847, specifically 8aa9ae88571a06f11d77944b39afb10257959804. Another piece of https://github.com/wagtail/wagtail/issues/7841.

Whilst they may be served from `.io` and `.org`, the bucket itself is `.io`. The `.org` bucket exists, but only to park in case of future use.